### PR TITLE
Bump mysql-connector version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2>=2.8.1
 sqlalchemy==1.3
-mysql-connector==2.1.6
+mysql-connector==2.1.7
 bs4
 cached_property


### PR DESCRIPTION
Mój pip twierdzi, że mysql-connector==2.1.6 (już?) nie istnieje.